### PR TITLE
The get_page_fault thrown exception because of the signal, the main t…

### DIFF
--- a/os_funcs.py
+++ b/os_funcs.py
@@ -441,7 +441,7 @@ class LinuxOS(OSFuncsInterface):
                              capture_output=True, shell=True)
 
         if res.returncode != 0 and psutil.pid_exists(psutil_process.pid):
-            raise Exception(f'An error occurred while getting process {psutil_process.pid} page faults', res.stderr)
+            raise ChildProcessError(f'An error occurred while getting process {psutil_process.pid} page faults', res.stderr)
 
         output_lines = res.stdout.decode("utf-8").strip().split("\n")
 

--- a/process_connections.py
+++ b/process_connections.py
@@ -50,7 +50,7 @@ class ProcessNetworkMonitor:
         """
         while not self._stop_sniffing:
             sniff(prn=self._process_packet, iface=self._interfaces,
-                  store=False, timeout=5, stop_filter=lambda _: self._stop_sniffing)
+                  store=False, timeout=3, stop_filter=lambda _: self._stop_sniffing)
 
     def _is_outgoing_packet(self, captured_packet):
         return captured_packet.src in self.device_mac_addresses or captured_packet.src in self.all_ips

--- a/process_connections.py
+++ b/process_connections.py
@@ -48,9 +48,12 @@ class ProcessNetworkMonitor:
         (since the stop_filter is examined upon receiving a packet)
         Hence, we force timeout to ensure that self._stop_sniffing is still False.
         """
-        while not self._stop_sniffing:
-            sniff(prn=self._process_packet, iface=self._interfaces,
-                  store=False, timeout=3, stop_filter=lambda _: self._stop_sniffing)
+        try:
+            while not self._stop_sniffing:
+                sniff(prn=self._process_packet, iface=self._interfaces,
+                      store=False, timeout=3, stop_filter=lambda _: self._stop_sniffing)
+        except PermissionError:
+            print("warning! per-process network measurements require elevations")
 
     def _is_outgoing_packet(self, captured_packet):
         return captured_packet.src in self.device_mac_addresses or captured_packet.src in self.all_ips

--- a/program_parameters.py
+++ b/program_parameters.py
@@ -7,7 +7,7 @@ background_programs_types = []  #[ProgramToScan.DummyANTIVIRUS, ProgramToScan.Pe
 kill_background_process_when_main_finished = True
 summary_version = SummaryVersion.OTHER
 
-scanner_version = ScannerVersion.FULL
+scanner_version = ScannerVersion.WITHOUT_BATTERY
 
 power_plan = PowerPlan.BALANCED
 scan_option = ScanMode.ONE_SCAN

--- a/scanner.py
+++ b/scanner.py
@@ -248,7 +248,9 @@ def add_to_processes_dataframe(time_of_sample, top_list, prev_data_per_process, 
                     }
                 )
 
-        except (psutil.NoSuchProcess, ChildProcessError):
+        # Note, we are just ignoring access denied and other exceptions and do not handle them.
+        # There will be no results for those processes
+        except (psutil.NoSuchProcess, psutil.AccessDenied, ChildProcessError):
             pass
 
     return prev_data_per_process

--- a/scanner.py
+++ b/scanner.py
@@ -248,7 +248,7 @@ def add_to_processes_dataframe(time_of_sample, top_list, prev_data_per_process, 
                     }
                 )
 
-        except psutil.NoSuchProcess:
+        except (psutil.NoSuchProcess, ChildProcessError):
             pass
 
     return prev_data_per_process


### PR DESCRIPTION
…hread exited without calling the stop function of the ProcessNetworkMonitor, and the sniffing thread continued endlessly