### PR TITLE
Windows is stupid so when the we join the measurement thread the prog…

### DIFF
--- a/operating_systems/abstract_operating_system.py
+++ b/operating_systems/abstract_operating_system.py
@@ -1,7 +1,8 @@
 import shlex
 import subprocess
+import threading
 from abc import abstractmethod
-from statistics import mean
+from threading import Thread
 
 import psutil
 
@@ -109,6 +110,9 @@ class AbstractOSFuncs:
             else:
                 raise e
 
+    def wait_for_measurement_termination(self, measurement_thread: Thread, done_scanning_event: threading.Event):
+        measurement_thread.join()
+
     @abstractmethod
     # TODO: make balance the default
     def change_power_plan(self, name, identifier):
@@ -131,7 +135,6 @@ class AbstractOSFuncs:
 
     def is_posix(self):
         pass
-
 
     @abstractmethod
     def get_container_total_cpu_usage(self) -> float:

--- a/operating_systems/os_windows.py
+++ b/operating_systems/os_windows.py
@@ -4,6 +4,8 @@ import subprocess
 import threading
 from threading import Thread
 
+from typing_extensions import override
+
 from general_consts import PowerPlan, pc_types, GB, physical_memory_types, disk_types
 from general_functions import get_powershell_result_list_format
 from operating_systems.abstract_operating_system import AbstractOSFuncs
@@ -209,6 +211,7 @@ class WindowsOS(AbstractOSFuncs):
     def get_container_total_memory_usage(self) -> tuple[float, float]:
         raise NotImplementedError("Not implemented total memory for windows container")
 
+    @override
     def wait_for_measurement_termination(self, measurement_thread: Thread, done_scanning_event: threading.Event):
         """
         Since signal handling in windows cannot be interrupted, while waiting to the measurement thread we cannot

--- a/operating_systems/os_windows.py
+++ b/operating_systems/os_windows.py
@@ -1,7 +1,8 @@
 import ctypes
 import platform
 import subprocess
-from statistics import mean
+import threading
+from threading import Thread
 
 from general_consts import PowerPlan, pc_types, GB, physical_memory_types, disk_types
 from general_functions import get_powershell_result_list_format
@@ -207,3 +208,14 @@ class WindowsOS(AbstractOSFuncs):
 
     def get_container_total_memory_usage(self) -> tuple[float, float]:
         raise NotImplementedError("Not implemented total memory for windows container")
+
+    def wait_for_measurement_termination(self, measurement_thread: Thread, done_scanning_event: threading.Event):
+        """
+        Since signal handling in windows cannot be interrupted, while waiting to the measurement thread we cannot
+        actively stop the program (for example, when using CTRL+C).
+        Hence, we have no choice but avoid blocking, and give a chance for interruption by the signal
+        """
+        while not done_scanning_event.wait(timeout=2):
+            pass
+
+        measurement_thread.join()


### PR DESCRIPTION
Windows is stupid so when we join the measurement thread the program cannot be interrupted, until the measurement thread is terminated.
This happens because thread.join is blocking so the main thread cannot be interrupted when it waits.