### PR TITLE
handle init of linux OS not inside container

### DIFF
--- a/initialization_helper.py
+++ b/initialization_helper.py
@@ -27,7 +27,7 @@ from tasks.program_classes.user_activity_program import UserActivityProgram
 # ======= Get Operating System Type =======
 running_os = None
 if platform.system() == "Linux":
-    running_os = LinuxOS()
+    running_os = LinuxOS(is_inside_container=is_inside_container)
 elif platform.system() == "Windows":
     running_os = WindowsOS()
 

--- a/operating_systems/os_linux.py
+++ b/operating_systems/os_linux.py
@@ -12,9 +12,10 @@ from resources_measurement.linux_resources.total_memory_usage import LinuxContai
 
 
 class LinuxOS(AbstractOSFuncs):
-    def __init__(self):
-        self.__container_cpu_usage_reader = LinuxContainerCPUReader()
-        self.__container_memory_usage_reader = LinuxContainerMemoryReader()
+    def __init__(self, is_inside_container: bool):
+        self.__container_cpu_usage_reader = LinuxContainerCPUReader() if is_inside_container else None
+        self.__container_memory_usage_reader = LinuxContainerMemoryReader() if is_inside_container else None
+
 
     @staticmethod
     def get_value_of_terminal_res(res):
@@ -156,9 +157,13 @@ class LinuxOS(AbstractOSFuncs):
 
 
     def get_container_total_cpu_usage(self) -> float:
+        if self.__container_cpu_usage_reader is None:
+            raise ValueError("Can't call this method when not inside container")
         return self.__container_cpu_usage_reader.get_cpu_percent()
 
     def get_container_total_memory_usage(self) -> tuple[float, float]:
+        if self.__container_memory_usage_reader is None:
+            raise ValueError("Can't call this method when not inside container")
         usage_in_bytes = self.__container_memory_usage_reader.get_memory_usage_bytes()
         usage_percent = self.__container_memory_usage_reader.get_memory_usage_percent()
         return usage_in_bytes, usage_percent

--- a/program_parameters.py
+++ b/program_parameters.py
@@ -34,7 +34,7 @@ screen_brightness_level = 75    # A number between 0 and 100
 DEFAULT_SCREEN_TURNS_OFF_TIME = 4
 DEFAULT_TIME_BEFORE_SLEEP_MODE = 4
 
-is_inside_container = True
+is_inside_container = False
 
 # ==== Elastic logging configuration
 elastic_url = "http://192.168.140.101:9200"


### PR DESCRIPTION
fix the error of files not exists when initalizing linux os without being inside container (since i previously initialized a cgroup object)